### PR TITLE
Update cpvpa to support replicaset and daemonset.  

### DIFF
--- a/cmd/cpvpa/options/options.go
+++ b/cmd/cpvpa/options/options.go
@@ -92,9 +92,13 @@ func isTargetFormatValid(target string) bool {
 		return false
 	}
 	target = strings.ToLower(target)
-	if !strings.HasPrefix(target, "deployment/") {
-		glog.Errorf("Unknown target format: must be deployment/* (not case sensitive).")
-		return false
+
+	if strings.HasPrefix(target, "deployment/") ||
+		strings.HasPrefix(target, "daemonset/") ||
+		strings.HasPrefix(target, "replicaset/") {
+		return true
 	}
-	return true
+
+	glog.Errorf("Unknown target format: must be one of deployment/*, daemonset/*, or replicaset/* (not case sensitive).")
+	return false
 }

--- a/cmd/cpvpa/options/options_test.go
+++ b/cmd/cpvpa/options/options_test.go
@@ -31,16 +31,24 @@ func TestIsTargetFormatValid(t *testing.T) {
 			true,
 		},
 		{
-			"replicationcontroller/anything",
-			true,
-		},
-		{
 			"replicaset/anything",
 			true,
 		},
 		{
 			"DeplOymEnT/anything",
 			true,
+		},
+		{
+			"daemonset/anything",
+			true,
+		},
+		{
+			"DaeMonSet/anything",
+			true,
+		},
+		{
+			"replicationcontroller/anything",
+			false,
 		},
 		{
 			"deployments/anything",
@@ -52,6 +60,10 @@ func TestIsTargetFormatValid(t *testing.T) {
 		},
 		{
 			"deployment",
+			false,
+		},
+		{
+			"daemonset",
 			false,
 		},
 	}

--- a/pkg/autoscaler/k8sclient/testing/mock_k8sclient.go
+++ b/pkg/autoscaler/k8sclient/testing/mock_k8sclient.go
@@ -34,8 +34,7 @@ func (k *MockK8sClient) GetClusterSize() (*k8sclient.ClusterSize, error) {
 	return &k8sclient.ClusterSize{k.NumOfNodes, k.NumOfCores}, nil
 }
 
-// UpdateReplicas mocks updating the number of replicas for the resource and return the previous replicas count
+// UpdateResources mocks updating resources needs for containers in the target
 func (k *MockK8sClient) UpdateResources(resources map[string]apiv1.ResourceRequirements) error {
-	//FIXME:
 	return nil
 }


### PR DESCRIPTION
Also updates unit tests for k8sClient and options.
Still need to update the documentation also needs updating.

Output of the daemonset run:

bin/amd64/cpvpa --target=daemonset/ip-masq-agent \
                --namespace=kube-system \
                --kubeconfig=$HOME/.kube/config \
                --logtostderr \
                --v=4 \
		     --poll-period-seconds=10 \
                --default-config=\
'{
  "ip-masq-agent": { 
    "requests": {
      "cpu": {
        "base": "10m", "increment":"1m", "coresPerIncrement":1
      },
	 "memory": {
	   "base": "8Mi", "increment":"1Mi", "coresPerIncrement":1
      }
    }
  }
}'      
I0816 17:43:14.038335   18390 autoscaler.go:49] Scaling namespace: kube-system, target: daemonset/ip-masq-agent
I0816 17:43:14.865824   18390 k8sclient.go:91] discovered target daemonset/ip-masq-agent = extensions/v1beta1.DaemonSet
I0816 17:43:14.944621   18390 autoscaler_server.go:101] Nodes     4
I0816 17:43:14.944659   18390 autoscaler_server.go:102] Cores     7
I0816 17:43:14.944683   18390 autoscaler_server.go:118] setting config = { [ip-masq-agent]: { requests: { [memory]: { base=8Mi incr=1Mi cores_incr=1 }, [cpu]: { base=10m incr=1m cores_incr=1 }, }, limits: { } }, }
I0816 17:43:14.944767   18390 autoscaler_server.go:132] Setting ip-masq-agent requests["memory"] = 15728640
I0816 17:43:14.944804   18390 autoscaler_server.go:132] Setting ip-masq-agent requests["cpu"] = 17m
I0816 17:43:24.910808   18390 autoscaler_server.go:101] Nodes     4
I0816 17:43:24.910847   18390 autoscaler_server.go:102] Cores     7
I0816 17:43:24.910885   18390 autoscaler_server.go:132] Setting ip-masq-agent requests["memory"] = 15728640
I0816 17:43:24.910932   18390 autoscaler_server.go:132] Setting ip-masq-agent requests["cpu"] = 17m
